### PR TITLE
Small security changes (salting and sha)

### DIFF
--- a/grails-app/conf/BootStrap.groovy
+++ b/grails-app/conf/BootStrap.groovy
@@ -15,7 +15,7 @@ class BootStrap {
     def _log = LogFactory.getLog('org.weceem.BootStrap')
     
     def wcmContentRepositoryService
-    
+    def springSecurityService
     def init = {servletContext ->
         def ctx = ApplicationHolder.application.mainContext
 
@@ -29,7 +29,7 @@ class BootStrap {
 
             if (!CMSUser.findByUsername('admin')) {
                 assert new CMSUser(username: 'admin', firstName: 'admin', lastName: '',
-                        passwd: '21232f297a57a5a743894a0e4a801fc3',
+                        passwd: "${springSecurityService.encodePassword('admin', 'admin')}",
                         email: 'admin@admin.com',
                         enabled: true)
                         .addToAuthorities(CMSRole.findWhere(authority: 'ROLE_ADMIN'))

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -83,7 +83,7 @@ grails {
             active = true
             //registerLoggerListener = true
 
-            password.algorithm = "MD5"
+            password.algorithm = "SHA-512"
             //use Base64 text ( true or false )
             password.encodeHashAsBase64 = false
             adh.errorPage = "null"

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -84,6 +84,7 @@ grails {
             //registerLoggerListener = true
 
             password.algorithm = "SHA-512"
+            dao.reflectionSaltSourceProperty = 'username'
             //use Base64 text ( true or false )
             password.encodeHashAsBase64 = false
             adh.errorPage = "null"

--- a/grails-app/controllers/org/weceem/user/UserProfileController.groovy
+++ b/grails-app/controllers/org/weceem/user/UserProfileController.groovy
@@ -33,7 +33,7 @@ class UserProfileController {
             assert form.newPass == form.confirmPass // Double double safety check!
             
             def user = CMSUser.get(springSecurityService.principal.id)
-            if (springSecurityService.encodePassword(form.current) == user.passwd) {
+            if (springSecurityService.encodePassword(form.current, user.username) == user.passwd) {
                 user.pass = form.newPass
                 user.save(flush:true) // User needs to know if this will fail
                 flash.message = 'user.password.changed'

--- a/grails-app/domain/org/weceem/auth/CMSUser.groovy
+++ b/grails-app/domain/org/weceem/auth/CMSUser.groovy
@@ -69,6 +69,6 @@ class CMSUser {
     }
     
     void setPass(String newPass) {
-        passwd = springSecurityService.encodePassword(newPass)
+        passwd = springSecurityService.encodePassword(newPass,username)
     }
 }

--- a/grails-app/domain/org/weceem/auth/CMSUser.groovy
+++ b/grails-app/domain/org/weceem/auth/CMSUser.groovy
@@ -50,8 +50,8 @@ class CMSUser {
         lastName(nullable: true, maxSize:40)
         description(nullable: true, maxSize:80)
         email(email:true, nullable: true, maxSize:40)
-        passwd(blank: false, nullable: false, maxSize:50)
-        pass(blank: false, nullable: false, maxSize:30) // This is just for UI form submission
+        passwd(blank: false, nullable: false, maxSize:128)
+        pass(blank: false, nullable: false, maxSize:128) // This is just for UI form submission
         enabled()
     }
 


### PR DESCRIPTION
These commits add salting to weceem passwords (for security), make the creation of the admin password (during bootstapping) dynamic to allow for (pre-bootstrap) hashing method changes (ie currently only MD5 would work because the admin password is hard coded) and change the default password hashing scheme to sha-512 (including increasing the password data field to match).
I don't know if you're interested in them at all but here they are if you'd like them :-) I was only going to do a pull request for the salting bit (sha-512 is more of a preference thing) but I got out of order, and my git-fu isn't awesome enough :-p

Changes tested, but not too extensively...
